### PR TITLE
Reduz drasticamente o tamanho da imagem de container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM mhart/alpine-node:6
 
-RUN apk add --no-cache make gcc g++ python
-
 # Create app directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install app dependencies
 COPY package.json /usr/src/app/
-RUN npm install
 
-RUN npm install pm2 -g
+RUN apk add --no-cache --virtual .build-deps make gcc g++ python && \
+    npm install && \
+    npm install pm2@^3 -g && \
+    npm cache clean && \
+    apk del .build-deps
 
 # Bundle app source
 COPY . /usr/src/app
@@ -18,4 +19,3 @@ COPY . /usr/src/app
 EXPOSE 8000
 
 CMD [ "pm2-docker", "app.js" ]
-


### PR DESCRIPTION
- fixa a versão do pm2 para 3
- utiliza melhor pratica de layer para redução de tamanho
- ignora Dockerfile e README.md


houve uma redução de 307 mb para 87.9mb, ajudando a rodar em dispositivos com Storage limitado.